### PR TITLE
Implement all-transactions listing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "sinatra", :require => false
 group :development do
   gem 'spring'
   gem 'sqlite3'
+  gem 'pry'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.3)
     builder (3.2.2)
+    coderay (1.1.1)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
     erubis (2.7.0)
@@ -51,6 +52,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -60,6 +62,10 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     pg (0.18.4)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     puma (3.4.0)
     rack (1.6.4)
     rack-protection (1.5.3)
@@ -108,6 +114,7 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    slop (3.6.0)
     spring (1.7.1)
     sprockets (3.6.2)
       concurrent-ruby (~> 1.0)
@@ -129,6 +136,7 @@ PLATFORMS
 DEPENDENCIES
   faraday
   pg
+  pry
   puma
   rails (= 4.2.6)
   rails-api

--- a/app/controllers/verify_controller.rb
+++ b/app/controllers/verify_controller.rb
@@ -9,8 +9,8 @@ class VerifyController < ApplicationController
           return unless msg
           @fb_user_id = get_user(message)
           @user = User.find_or_create_by(facebook_id: @fb_user_id)
-          response_msg = parse_message(msg["text"].downcase.strip)
-          process_message(@fb_user_id, response_msg)
+          response = parse_message(msg["text"].downcase.strip)
+          process_message(@fb_user_id, response)
         end
       end
     end
@@ -22,24 +22,26 @@ class VerifyController < ApplicationController
 
   def parse_message(msg)
     if msg =~ Reminder.reminder_pattern
-      Reminder.process_reminder(msg, @user.id, @fb_user_id)
+      { template: 'default', message: Reminder.process_reminder(msg, @user.id, @fb_user_id) } 
     elsif msg == "list debtors"
-      list_debtors(@user.debtors)
+      { template: 'default', message: list_debtors(@user.debtors) }
     elsif msg =~ /(\w+)\s(refunded|paid)\s(\d+)/
       debtor_name = $1
       amount = $3
       debtor = @user.debtors.find_by(name: debtor_name)
-      manage_debt(debtor, amount, debtor_name)
+      { template: 'default', message: manage_debt(debtor, amount, debtor_name) }
     elsif msg =~ /^(\w+)\sborrowed\s(\d+)$/
-      debtor = $1
+      new_debtor = $1
       amount = $2
-      old_debtor = Debtor.find_by(name: debtor)
-      manage_debtor(old_debtor, debtor, amount)
+      old_debtor = Debtor.find_by(name: new_debtor)
+      { template: 'default', message: manage_debtor(old_debtor, new_debtor, amount) }
     elsif msg =~ /remove\s(\w+)/
       debtor_name = $1
-      remove_debtor(debtor_name)
+      { template: 'default', message: remove_debtor(debtor_name) }
+    elsif msg =~ /(view|show)\stransactions(\s--sort)?/
+      { template: 'receipt', message: show_transactions($2) }
     else
-      list_commands.join("\n")
+      { template: 'default', message: list_commands.join("\n") }
     end
   end
 
@@ -47,27 +49,42 @@ class VerifyController < ApplicationController
     debtor = Debtor.find_by(name: debtor_name)
     if debtor
       debtor.destroy
+      @user.transactions.create({
+        description: "You removed #{debtor_name} from your debtors list",
+        debtor: debtor_name
+      })      
       "#{debtor_name} has been removed"
     else
       "#{debtor_name} is invalid or does not exist"
     end
   end
 
-  def manage_debtor(old_debtor, debtor, amount)
-    if old_debtor
-      old_debtor.amount += amount.to_f
-      old_debtor.save
-      "#{old_debtor.name} is owing #{old_debtor.amount}"
+  def manage_debtor(debtor, new_debtor, amount)
+    if debtor
+      debtor.amount += amount.to_f
+      debtor.save
     else
-      new_debtor = @user.debtors.create(name: debtor, amount: amount)
-      "#{new_debtor.name} is owing #{new_debtor.amount}"
+      debtor = @user.debtors.create(name: new_debtor, amount: amount)
     end
+    @user.transactions.create({
+      description: "#{debtor.name} borrowed #{amount.to_f}",
+      debtor: debtor.name,
+      amount: amount.to_f,
+      balance: debtor.amount
+    })            
+    "#{debtor.name} is owing #{debtor.amount}"
   end
 
   def manage_debt(debtor, amount, debtor_name)
-    if debtor && debtor.amount.to_i >= amount.to_i
+    if debtor && debtor.amount.to_f >= amount.to_f
       debtor.amount -= amount.to_f
       debtor.save
+      @user.transactions.create({
+        description: "#{debtor.name} refunded #{amount.to_f}",
+        debtor: debtor.name,
+        amount: amount.to_f,
+        balance: debtor.amount
+      })      
       "#{debtor.name} debt now #{debtor.amount}"
     else
       "#{debtor_name} does not exist or amount is invalid"
@@ -86,7 +103,10 @@ class VerifyController < ApplicationController
       "",
       "To deduct amount from loan use this:: <name> paid || refunded <amount>",
       "",
-      "To set reminder for debt use: <remind me in> [time in digit e.g 5] [time category e.g mins, hours, days, weeks etc] <that> [borrower's name] <borrowed> [amount]"
+      "To set reminder for debt use: <remind me in> [time in digit e.g 5] [time category e.g mins, hours, days, weeks etc] <that> [borrower's name] <borrowed> [amount]",
+      "",
+      "To show all transactions: <show | list> transactions",
+      "To show all transactions, sorted by debtor: <show | list> transactions --sort"
     ]
   end
 
@@ -95,26 +115,72 @@ class VerifyController < ApplicationController
     debtors.map{|debtor| "#{debtor.name} is owing #{debtor.amount}"}.join("\n")
   end
 
+  def show_transactions(sort)
+    puts sort
+    return @user.transactions.all.order(:debtor) if sort == ' --sort'
+    @user.transactions.all
+  end
+
   def get_user(messaging)
     messaging["sender"]["id"]
   end
 
-  def process_message(user_id, response_msg)
-    make_request(user_id, response_msg)
+  def process_message(user_id, response)
+    if response[:template] == 'default'
+      message = default_template(response[:message])
+    elsif response[:template] == 'receipt'
+      message = receipt_template(response[:message])
+    end
+    make_request(user_id, message)
+  end
+
+  def default_template(message)
+    { text: message }
+  end
+
+  def receipt_template(object)
+    {
+      attachment:{
+        type:"template",
+        payload:{
+          template_type:"receipt",
+          recipient_name: @user.facebook_id,
+          order_number: @user.facebook_id,
+          currency:"NGN",
+          payment_method:"Visa",        
+          order_url:"",
+          timestamp:"", 
+          elements: object.map { |entry| {
+            title: entry.debtor,
+            subtitle: entry.description,
+            price: entry.amount,
+            currency: "NGN"
+          }},
+          address:{},
+          summary:{
+            total_cost: @user.debtors.sum(:amount)
+          },
+          adjustments:[]
+        }
+      }
+    }
   end
 
   def make_request(user_id, message)
-    message = {
+    response = {
       recipient: { id: user_id },
-      message: { text: message }
+      message: message
     }
-    token = ENV["facebook_token"]
+
+    token = "ENV["facebook_token"]"
     uri = 'https://graph.facebook.com/v2.6/me/messages'
     uri += '?access_token=' + token
 
     Faraday.new(url: uri).post do |req|
-      req.body = message.to_json
+      req.body = response.to_json
       req.headers['Content-Type'] = 'application/json'
     end
+    # puts response.inspect
+    # render json: { message: response }, status: 200
   end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,0 +1,3 @@
+class Transaction < ActiveRecord::Base
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ActiveRecord::Base
   has_many :debtors
+  has_many :transactions
 end

--- a/db/migrate/20160722180809_create_transactions.rb
+++ b/db/migrate/20160722180809_create_transactions.rb
@@ -1,0 +1,13 @@
+class CreateTransactions < ActiveRecord::Migration
+  def change
+    create_table :transactions do |t|
+      t.text :description
+      t.string :debtor
+      t.float :amount, default: 0
+      t.float :balance, default: 0
+      t.references :user, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160622104113) do
+ActiveRecord::Schema.define(version: 20160722180809) do
 
   create_table "debtors", force: :cascade do |t|
     t.string   "name"
@@ -22,6 +22,18 @@ ActiveRecord::Schema.define(version: 20160622104113) do
   end
 
   add_index "debtors", ["user_id"], name: "index_debtors_on_user_id"
+
+  create_table "transactions", force: :cascade do |t|
+    t.text     "description"
+    t.string   "debtor"
+    t.float    "amount",      default: 0.0
+    t.float    "balance",     default: 0.0
+    t.integer  "user_id"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "transactions", ["user_id"], name: "index_transactions_on_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "facebook_id"

--- a/test/fixtures/transactions.yml
+++ b/test/fixtures/transactions.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  description: MyText
+
+two:
+  description: MyText

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TransactionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#### This PR implements transactions listing by doing the following:
- Add migration to add the `transactions` table.
- Change the response from `parse_message` to Hash containing the template and the message text/object
- Create a new record in the `transactions` table for every transaction that occurs.
- Add another rule to `show|view transactions using the FB receipt template.
